### PR TITLE
Refactor JSON parsing helpers

### DIFF
--- a/Tools/AutomaticQueryBuilder.cs
+++ b/Tools/AutomaticQueryBuilder.cs
@@ -346,7 +346,7 @@ public static class AutomaticQueryBuilder
                 return new Dictionary<string, object>();
 
             using var document = JsonDocument.Parse(variables);
-            return JsonElementToDictionary(document.RootElement);
+            return JsonHelpers.JsonElementToDictionary(document.RootElement);
         }
         catch
         {
@@ -354,32 +354,6 @@ public static class AutomaticQueryBuilder
         }
     }
 
-    private static Dictionary<string, object> JsonElementToDictionary(JsonElement element)
-    {
-        var dictionary = new Dictionary<string, object>();
-
-        foreach (var property in element.EnumerateObject())
-        {
-            dictionary[property.Name] = JsonElementToObject(property.Value);
-        }
-
-        return dictionary;
-    }
-
-    private static object JsonElementToObject(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.String => element.GetString() ?? "",
-            JsonValueKind.Number => element.TryGetInt32(out var intValue) ? intValue : element.GetDouble(),
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Null => null!,
-            JsonValueKind.Array => element.EnumerateArray().Select(JsonElementToObject).ToArray(),
-            JsonValueKind.Object => JsonElementToDictionary(element),
-            _ => element.ToString()
-        };
-    }
 
     private static string BuildOperationFieldSelection(JsonElement operationField, JsonElement schema, int maxDepth, bool includeAllScalars, string operationName)
     {

--- a/Tools/DynamicToolRegistry.cs
+++ b/Tools/DynamicToolRegistry.cs
@@ -136,7 +136,7 @@ public static class DynamicToolRegistry
                 try
                 {
                     using var document = JsonDocument.Parse(variables);
-                    variableDict = JsonElementToDictionary(document.RootElement);
+                    variableDict = JsonHelpers.JsonElementToDictionary(document.RootElement);
                 }
                 catch (JsonException ex)
                 {
@@ -522,32 +522,6 @@ public static class DynamicToolRegistry
         return description.ToString();
     }
 
-    private static Dictionary<string, object> JsonElementToDictionary(JsonElement element)
-    {
-        var dictionary = new Dictionary<string, object>();
-
-        foreach (var property in element.EnumerateObject())
-        {
-            dictionary[property.Name] = JsonElementToObject(property.Value);
-        }
-
-        return dictionary;
-    }
-
-    private static object JsonElementToObject(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.String => element.GetString() ?? "",
-            JsonValueKind.Number => element.TryGetInt32(out var intValue) ? intValue : element.GetDouble(),
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Null => null!,
-            JsonValueKind.Array => element.EnumerateArray().Select(JsonElementToObject).ToArray(),
-            JsonValueKind.Object => JsonElementToDictionary(element),
-            _ => element.ToString()
-        };
-    }
 
     private static string FormatGraphQLResponse(string responseContent)
     {

--- a/Tools/JsonHelpers.cs
+++ b/Tools/JsonHelpers.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using System.Linq;
+
+namespace Tools;
+
+/// <summary>
+/// Utility helpers for converting <see cref="JsonElement"/> values
+/// into CLR types.
+/// </summary>
+public static class JsonHelpers
+{
+    /// <summary>
+    /// Convert a <see cref="JsonElement"/> object into a dictionary representation.
+    /// </summary>
+    public static Dictionary<string, object> JsonElementToDictionary(JsonElement element)
+    {
+        var dictionary = new Dictionary<string, object>();
+        foreach (var property in element.EnumerateObject())
+        {
+            dictionary[property.Name] = JsonElementToObject(property.Value);
+        }
+        return dictionary;
+    }
+
+    /// <summary>
+    /// Convert a <see cref="JsonElement"/> to a corresponding CLR object.
+    /// </summary>
+    public static object JsonElementToObject(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString() ?? string.Empty,
+            JsonValueKind.Number => element.TryGetInt32(out var i) ? i : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null!,
+            JsonValueKind.Array => element.EnumerateArray().Select(JsonElementToObject).ToArray(),
+            JsonValueKind.Object => JsonElementToDictionary(element),
+            _ => element.ToString()
+        };
+    }
+}

--- a/Tools/QueryGraphQLMcpTool.cs
+++ b/Tools/QueryGraphQLMcpTool.cs
@@ -62,7 +62,7 @@ public static class QueryGraphQLMcpTool
                 try
                 {
                     using var document = JsonDocument.Parse(variables);
-                    variableDict = JsonElementToDictionary(document.RootElement);
+                    variableDict = JsonHelpers.JsonElementToDictionary(document.RootElement);
                 }
                 catch (JsonException ex)
                 {
@@ -90,30 +90,4 @@ public static class QueryGraphQLMcpTool
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
 
-    private static Dictionary<string, object> JsonElementToDictionary(JsonElement element)
-    {
-        var dictionary = new Dictionary<string, object>();
-
-        foreach (var property in element.EnumerateObject())
-        {
-            dictionary[property.Name] = JsonElementToObject(property.Value);
-        }
-
-        return dictionary;
-    }
-
-    private static object JsonElementToObject(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.String => element.GetString() ?? "",
-            JsonValueKind.Number => element.TryGetInt32(out var intValue) ? intValue : element.GetDouble(),
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Null => null!,
-            JsonValueKind.Array => element.EnumerateArray().Select(JsonElementToObject).ToArray(),
-            JsonValueKind.Object => JsonElementToDictionary(element),
-            _ => element.ToString()
-        };
-    }
 }


### PR DESCRIPTION
## Summary
- centralize JsonElement conversion logic in new `JsonHelpers`
- use the helper in QueryGraphQLMcpTool
- use the helper in DynamicToolRegistry
- use the helper in AutomaticQueryBuilder

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498b916b0c8321b5613a4e69de1627