### PR TITLE
Return GraphQlResponse from IntrospectSchema

### DIFF
--- a/Helpers/GraphQLSchemaHelper.cs
+++ b/Helpers/GraphQLSchemaHelper.cs
@@ -15,8 +15,11 @@ public static class GraphQlSchemaHelper
     /// </summary>
     public static async Task<string> GenerateToolsFromSchema(GraphQlEndpointInfo endpointInfo)
     {
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) || !data.TryGetProperty("__schema", out var schema))
         {
@@ -39,8 +42,11 @@ public static class GraphQlSchemaHelper
     /// </summary>
     public static async Task<JsonElement> GetSchemaAsync(GraphQlEndpointInfo endpointInfo)
     {
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            throw new InvalidOperationException(schemaResult.FormatForDisplay());
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))

--- a/Tools/CodeGenerationTools.cs
+++ b/Tools/CodeGenerationTools.cs
@@ -22,8 +22,11 @@ public static class CodeGenerationTools
             return $"Error: Endpoint '{endpointName}' not found. Please register the endpoint first using RegisterEndpoint.";
         }
 
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema) ||
@@ -183,8 +186,11 @@ public static class CodeGenerationTools
         }
 
         // Get schema to understand available fields
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         var generatedCode = new StringBuilder();
         generatedCode.AppendLine("using System;");

--- a/Tools/FieldUsageAnalyticsTools.cs
+++ b/Tools/FieldUsageAnalyticsTools.cs
@@ -33,8 +33,11 @@ public static class FieldUsageAnalyticsTools
             return "Error: No queries found in log";
         }
 
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaFields = await ExtractSchemaFields(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaFields = await ExtractSchemaFields(schemaResult.Content!);
 
         var usageStats = AnalyzeFieldUsageFromQueries(queries, schemaFields);
 

--- a/Tools/GraphQLSchemaTools.cs
+++ b/Tools/GraphQLSchemaTools.cs
@@ -26,8 +26,11 @@ public static class GraphQlSchemaTools
             return $"Error: Endpoint '{endpointName}' not found. Please register the endpoint first using RegisterEndpoint.";
         }
 
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))
@@ -114,11 +117,15 @@ public static class GraphQlSchemaTools
         }
 
         // Get both schemas
-        var schema1Json = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo1);
-        var schema2Json = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo2);
+        var schema1Result = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo1);
+        if (!schema1Result.IsSuccess)
+            return schema1Result.FormatForDisplay();
+        var schema2Result = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo2);
+        if (!schema2Result.IsSuccess)
+            return schema2Result.FormatForDisplay();
 
-        var schema1Data = JsonSerializer.Deserialize<JsonElement>(schema1Json);
-        var schema2Data = JsonSerializer.Deserialize<JsonElement>(schema2Json);
+        var schema1Data = JsonSerializer.Deserialize<JsonElement>(schema1Result.Content!);
+        var schema2Data = JsonSerializer.Deserialize<JsonElement>(schema2Result.Content!);
 
         if (!schema1Data.TryGetProperty("data", out var data1) ||
             !data1.TryGetProperty("__schema", out var schema1) ||

--- a/Tools/QueryAnalyzerTools.cs
+++ b/Tools/QueryAnalyzerTools.cs
@@ -130,8 +130,11 @@ public static class QueryAnalyzerTools
         }
 
         // Get schema to understand available fields
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))

--- a/Tools/QueryValidationTools.cs
+++ b/Tools/QueryValidationTools.cs
@@ -58,25 +58,31 @@ public static class QueryValidationTools
         result.AppendLine("## Schema Validation");
         try
         {
-            var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-            var schemaErrors = ValidateQueryAgainstSchema(query, schemaJson);
-
-            if (schemaErrors.Any())
+            var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+            if (!schemaResult.IsSuccess)
             {
-                result.AppendLine("❌ **Status:** Schema validation errors\n");
-                result.AppendLine("**Errors:**");
-                foreach (var error in schemaErrors)
-                {
-                    result.AppendLine($"- {error}");
-                }
-
-                result.AppendLine();
+                result.AppendLine(schemaResult.FormatForDisplay());
             }
             else
             {
-                result.AppendLine("✅ **Status:** Query is valid against schema\n");
+                var schemaErrors = ValidateQueryAgainstSchema(query, schemaResult.Content!);
+
+                if (schemaErrors.Any())
+                {
+                    result.AppendLine("❌ **Status:** Schema validation errors\n");
+                    result.AppendLine("**Errors:**");
+                    foreach (var error in schemaErrors)
+                    {
+                        result.AppendLine($"- {error}");
+                    }
+
+                    result.AppendLine();
+                }
+                else
+                {
+                    result.AppendLine("✅ **Status:** Query is valid against schema\n");
+                }
             }
-        }
         catch (Exception ex)
         {
             result.AppendLine($"⚠️ **Status:** Could not validate against schema: {ex.Message}\n");

--- a/Tools/ResolverDocumentationTools.cs
+++ b/Tools/ResolverDocumentationTools.cs
@@ -28,8 +28,11 @@ public static class ResolverDocumentationTools
         }
 
         // Get schema introspection
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))
@@ -114,8 +117,11 @@ public static class ResolverDocumentationTools
         }
 
         // Get schema introspection
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))
@@ -174,8 +180,11 @@ public static class ResolverDocumentationTools
         performanceDoc.AppendLine("# GraphQL Resolver Performance Guide\n");
 
         // Get schema for analysis
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema))

--- a/Tools/SchemaEvolutionTools.cs
+++ b/Tools/SchemaEvolutionTools.cs
@@ -164,8 +164,11 @@ public static class SchemaEvolutionTools
             // Check if it's a URL
             if (Uri.TryCreate(schemaSource, UriKind.Absolute, out _))
             {
-                var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(schemaSource);
-                var data = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+                var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(schemaSource);
+                if (!schemaResult.IsSuccess)
+                    return null;
+
+                var data = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
                 if (data.TryGetProperty("data", out var schemaData))
                 {
                     return schemaData;

--- a/Tools/SecurityAnalysisTools.cs
+++ b/Tools/SecurityAnalysisTools.cs
@@ -312,8 +312,11 @@ public static class SecurityAnalysisTools
     {
         try
         {
-            var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-            var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+            var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+            if (!schemaResult.IsSuccess)
+                return schemaResult.FormatForDisplay();
+
+            var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
             var result = new StringBuilder();
 

--- a/Tools/TestingMockingTools.cs
+++ b/Tools/TestingMockingTools.cs
@@ -25,8 +25,11 @@ public static class TestingMockingTools
         }
 
         // Get schema introspection
-        var schemaJson = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
-        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaJson);
+        var schemaResult = await SchemaIntrospectionTools.IntrospectSchema(endpointInfo);
+        if (!schemaResult.IsSuccess)
+            return schemaResult.FormatForDisplay();
+
+        var schemaData = JsonSerializer.Deserialize<JsonElement>(schemaResult.Content!);
 
         if (!schemaData.TryGetProperty("data", out var data) ||
             !data.TryGetProperty("__schema", out var schema) ||
@@ -175,11 +178,15 @@ public static class TestingMockingTools
         }
 
         // Get both schemas
-        var originalSchemaJson = await SchemaIntrospectionTools.IntrospectSchema(originalEndpointInfo);
-        var newSchemaJson = await SchemaIntrospectionTools.IntrospectSchema(newEndpointInfo);
+        var originalResult = await SchemaIntrospectionTools.IntrospectSchema(originalEndpointInfo);
+        if (!originalResult.IsSuccess)
+            return originalResult.FormatForDisplay();
+        var newResult = await SchemaIntrospectionTools.IntrospectSchema(newEndpointInfo);
+        if (!newResult.IsSuccess)
+            return newResult.FormatForDisplay();
 
-        var originalSchema = JsonSerializer.Deserialize<JsonElement>(originalSchemaJson);
-        var newSchema = JsonSerializer.Deserialize<JsonElement>(newSchemaJson);
+        var originalSchema = JsonSerializer.Deserialize<JsonElement>(originalResult.Content!);
+        var newSchema = JsonSerializer.Deserialize<JsonElement>(newResult.Content!);
 
         var comparison = new StringBuilder();
         comparison.AppendLine("# GraphQL Schema Comparison Report\n");


### PR DESCRIPTION
## Summary
- update `SchemaIntrospectionTools.IntrospectSchema` to return `GraphQlResponse`
- adjust helpers and tools to handle new response type

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685316515e048321a083413041f07e36