### PR TITLE
Fix missing using directives for schema and operation helpers

### DIFF
--- a/Helpers/GraphQLOperationHelper.cs
+++ b/Helpers/GraphQLOperationHelper.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using System.Text.Json;
 using HotChocolate.Language;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Graphql.Mcp.Helpers;
 

--- a/Helpers/GraphQLToolGenerator.cs
+++ b/Helpers/GraphQLToolGenerator.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
 using Graphql.Mcp.DTO;
 using HotChocolate.Language;
 

--- a/Tools/GraphQLSchemaTools.cs
+++ b/Tools/GraphQLSchemaTools.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
+using System.Collections.Generic;
 using Graphql.Mcp.DTO;
 using Graphql.Mcp.Helpers;
 using ModelContextProtocol.Server;


### PR DESCRIPTION
## Summary
- include `System.Linq` and `System.Collections.Generic` in GraphQLSchemaTools
- include `System.Linq` and `System.Collections.Generic` in GraphQLToolGenerator
- include `System.Linq` and `System.Collections.Generic` in GraphQLOperationHelper

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68535c678e8083218eb2a3f089bab861